### PR TITLE
docs: Fix links to Basler SDK

### DIFF
--- a/docs/ADPylon/ADPylon.rst
+++ b/docs/ADPylon/ADPylon.rst
@@ -9,7 +9,7 @@ ADPylon
 .. _GenICam:      https://www.emva.org/standards-technology/genicam
 .. _ADGenICam:    https://github.com/areaDetector/ADGenICam
 .. _ADPylon:      https://github.com/areaDetector/ADPylon
-.. _Pylon:        https://www.baslerweb.com/en/products/basler-pylon-camera-software-suite/pylon-sdks
+.. _Pylon:        https://www.baslerweb.com/en/software/pylon/sdk/
 .. _ADPylon class: ../areaDetectorDoxygenHTML/class_a_d_pylon.html
 
 Overview


### PR DESCRIPTION
Seems like the URL of the Basler SDK page has changed, as the previous link only shows a 404